### PR TITLE
Typescript definition added

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+import Vue, {PluginFunction, PluginObject} from "vue";
+import {AxiosInstance} from "axios";
+
+declare module "vue/types/vue" {
+
+  interface Vue {
+    axios: AxiosInstance;
+    $http: AxiosInstance;
+  }
+
+  namespace Vue {
+    const axios: AxiosInstance;
+  }
+
+}
+
+declare class VueAxios {
+  static install: PluginFunction<AxiosInstance>;
+}
+
+export = VueAxios

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "description": "A small wrapper for integrating axios to Vuejs",
   "main": "dist/vue-axios.min.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "npm run test"
   },
@@ -26,12 +27,14 @@
   },
   "homepage": "https://github.com/imcvampire/vue-axios#readme",
   "devDependencies": {
+    "axios": "^0.17.1",
     "babel-core": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-rename": "^1.2.2",
-    "gulp-uglifyjs": "^0.6.2"
+    "gulp-uglifyjs": "^0.6.2",
+    "vue": "^2.5.13"
   },
   "peerDependencies": {
     "vue": ">= 1.0.0"


### PR DESCRIPTION
This adds the index.d.ts file to the library to let users use typescript with `vue-axios` without making them write a custom definition.

Packages added:
- `axios`: needed to get the actual axios ts definition
- `vue`: needed to import the plugin types to our ts definition

Let me know if this looks good to you, and don't hesitate to contact me if there's any problem with ts definitions in the future ;)