### PR TITLE
docs: update the way of import Vue in Vue3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ npm install --save axios vue-axios
 ```
 Import libraries in entry file:
 ```js
-import Vue from 'vue'
+// import Vue from 'vue'   // in Vue 2
+import * as Vue from 'vue' // in Vue 3
 import axios from 'axios'
 import VueAxios from 'vue-axios'
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function plugin(app, axios) {
   }
 
   if (semver.valid(app.version) == null) {
-    console.error('Unkown vue version');
+    console.error('Unknown vue version');
     return;
   }
 


### PR DESCRIPTION
in Vue 3, we should import it like this:
```js
import * as Vue from 'vue' // import Vue from 'vue' will cause undefined createApp error
import axios from 'axios'
import VueAxios from 'vue-axios'

const app = Vue.createApp(...)
app.use(VueAxios, axios)
```